### PR TITLE
Peaks detection correction

### DIFF
--- a/medaka_bpm.py
+++ b/medaka_bpm.py
@@ -264,8 +264,7 @@ def main(args):
                 consolidate_cmd, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
 
         except Exception as e:
-            LOGGER.exception(
-                "During dispatching of jobs onto the cluster")
+            LOGGER.exception("During dispatching of jobs onto the cluster")
 
     elif args.only_crop == False:
         bpm = None

--- a/medaka_bpm.py
+++ b/medaka_bpm.py
@@ -146,7 +146,8 @@ def main(args):
     setup.config_logger(
         args.outdir, ("logfile_" + experiment_id + ".log"), args.debug)
 
-    LOGGER.info("Program started with the following arguments: " + str(sys.argv[1:]))
+    LOGGER.info("Program started with the following arguments: " +
+                str(sys.argv[1:]))
 
     ################################## MAIN PROGRAM START ##################################
     LOGGER.info("##### MedakaBPM #####")
@@ -186,8 +187,10 @@ def main(args):
                     args.channels = channel
                     args.loops = loop
 
-                    arguments_variable = [['--' + key, str(value)] for key, value in vars(args).items() if value and value is not True]
-                    arguments_bool = ['--' + key for key, value in vars(args).items() if value is True]
+                    arguments_variable = [
+                        ['--' + key, str(value)] for key, value in vars(args).items() if value and value is not True]
+                    arguments_bool = ['--' + key for key,
+                                      value in vars(args).items() if value is True]
                     arguments = sum(arguments_variable, arguments_bool)
 
                     exe_path = os.path.join(main_directory, 'cluster.py')
@@ -229,8 +232,8 @@ def main(args):
             # Create a dependent job for final report
             job_ids = [("ended(" + s + ")") for s in job_ids]
             w_condition = '&&'.join(job_ids)
-            
-            # assign unique name. 
+
+            # assign unique name.
             # Target completion of all experiment analysis with ended(HRConsolidate-*).
             # Needed in test_accuracy when JOB_DEP_LAST_SUB = 1 in lsb.params.
             unique_job_name = "HRConsolidate-" + str(job_ids[0])
@@ -265,6 +268,7 @@ def main(args):
                 "During dispatching of jobs onto the cluster")
 
     elif args.only_crop == False:
+        bpm = None
         LOGGER.info("Running on a single machine")
         results = {'channel': [], 'loop': [],
                    'well': [], 'heartbeat': []}
@@ -275,8 +279,6 @@ def main(args):
                 LOGGER.info(
                     "The analyse for each well can take about from one to several minutes\n")
                 LOGGER.info("Running....please wait...")
-
-                bpm = None
 
                 try:
                     bpm = run_algorithm(

--- a/src/segment_heart.py
+++ b/src/segment_heart.py
@@ -1108,8 +1108,6 @@ def PixelSignal(grey_frames):
     return(pixel_signals)
 
 # Plot multiple pixel signal intensities on same graph
-
-
 def PixelFourier(pixel_signals, times, empty_frames, frame2frame, threads, pixel_num=None, heart_range=(0.5, 5), plot=False):
     """
     Plot multiple pixel signal intensities on same graph
@@ -1193,8 +1191,6 @@ def PixelFourier(pixel_signals, times, empty_frames, frame2frame, threads, pixel
         return(highest_freqs)
 
 # ## Function PixelNorm(pixel, pixel_signals, times, empty_frames, heart_range, plot = False):
-
-
 def PixelNorm(pixel, pixel_signals, times, empty_frames, heart_range, td, plot=False):
 
     pixel_signal = pixel_signals[pixel]
@@ -1234,10 +1230,7 @@ def PixelNorm(pixel, pixel_signals, times, empty_frames, heart_range, td, plot=F
     return(highest_freq)
 
 # ## Function PixelFreqs(frequencies, figsize = (10,7), heart_range = (0.5, 5), peak_filter = True)
-
-
 def PixelFreqs(frequencies, average_values, figsize=(10, 7), heart_range=(0.5, 5), peak_filter=True, slow_mode=False):
-
     sns.set_style('white')
     ax = plt.subplot()
 
@@ -1261,8 +1254,7 @@ def PixelFreqs(frequencies, average_values, figsize=(10, 7), heart_range=(0.5, 5
             frequencies, stat='density', bins=500).patches])
 
         # Plot Histogram
-        _ = sns.histplot(frequencies, ax=ax, fill=True,
-                         stat='density', bins=500)
+        _ = sns.histplot(frequencies, ax=ax, fill=True, stat='density', bins=500)
 
         _ = ax.set_title("Pixel Fourier Transform Maxima")
         _ = ax.set_xlabel('Frequency (Hz)')
@@ -1434,18 +1426,21 @@ def PixelFreqs(frequencies, average_values, figsize=(10, 7), heart_range=(0.5, 5
                 bpm_label = str(int(bpm)) + " bpm"
                 _ = ax.plot(xs[index_for_plotting],
                             ys[index_for_plotting], 'bo', ms=10)
-                _ = ax.annotate(bpm_label, xy=(xs[index_for_plotting], ys[index_for_plotting]), xytext=(xs[index_for_plotting] + (
-                    xs[index_for_plotting] * 0.1), ys[index_for_plotting] + (ys[index_for_plotting] * 0.01)), arrowprops=dict(facecolor='black', shrink=0.05))
+                _ = ax.annotate(bpm_label, 
+                                xy=(xs[index_for_plotting], ys[index_for_plotting]), 
+                                xytext=(xs[index_for_plotting] + (xs[index_for_plotting] * 0.1), ys[index_for_plotting] + (ys[index_for_plotting] * 0.01)), 
+                                arrowprops=dict(facecolor='black', shrink=0.05))
 
             # more than 2 peaks, first delete the farthest peak from the peaks average,as is is suposed to be a error.
             elif len(peaks) > 2:
                 LOGGER.info("Found more than 2 peaks in slow mode")
                 x_values = [xs[i] for i in peaks]
                 averaged_peak_values = statistics.mean(x_values)
-                def absolute_difference_function(list_value): return abs(
-                    list_value - averaged_peak_values)
-                farthest_value = max(
-                    x_values, key=absolute_difference_function)
+
+                def absolute_difference_function(list_value): 
+                    return abs(list_value - averaged_peak_values)
+                farthest_value = max(x_values, key=absolute_difference_function)
+
                 #x_list = xs.tolist()
                 index_for_deletion = x_values.index(farthest_value)
                 peaks = np.delete(peaks, index_for_deletion)
@@ -1463,8 +1458,10 @@ def PixelFreqs(frequencies, average_values, figsize=(10, 7), heart_range=(0.5, 5
                 bpm_label = str(int(bpm)) + " bpm"
                 _ = ax.plot(xs[index_for_plotting],
                             ys[index_for_plotting], 'bo', ms=10)
-                _ = ax.annotate(bpm_label, xy=(xs[index_for_plotting], ys[index_for_plotting]), xytext=(xs[index_for_plotting] + (
-                    xs[index_for_plotting] * 0.1), ys[index_for_plotting] + (ys[index_for_plotting] * 0.01)), arrowprops=dict(facecolor='black', shrink=0.05))
+                _ = ax.annotate(bpm_label, 
+                                xy=(xs[index_for_plotting], ys[index_for_plotting]), 
+                                xytext=(xs[index_for_plotting] + (xs[index_for_plotting] * 0.1), ys[index_for_plotting] + (ys[index_for_plotting] * 0.01)), 
+                                arrowprops=dict(facecolor='black', shrink=0.05))
 
             else:
                 LOGGER.info("No peaks detected, trying power over the peaks")
@@ -1472,8 +1469,7 @@ def PixelFreqs(frequencies, average_values, figsize=(10, 7), heart_range=(0.5, 5
                 peaks, _ = find_peaks(powered_list)
 
                 if len(peaks) > 0:
-                    LOGGER.info(
-                        "Found " + str(len(peaks)) + " peaks. We will select the one that represents the highest bpm")
+                    LOGGER.info("Found " + str(len(peaks)) + " peaks. We will select the one that represents the highest bpm")
                     x_values = [xs[i] for i in peaks]
                     highest_value = max(x_values)
                     x_list = xs.tolist()
@@ -1483,10 +1479,11 @@ def PixelFreqs(frequencies, average_values, figsize=(10, 7), heart_range=(0.5, 5
 
                     # plot with the correct peak index
                     bpm_label = str(int(bpm)) + " bpm"
-                    _ = ax.plot(xs[index_for_plotting],
-                                ys[index_for_plotting], 'bo', ms=10)
-                    _ = ax.annotate(bpm_label, xy=(xs[index_for_plotting], ys[index_for_plotting]), xytext=(xs[index_for_plotting] + (
-                        xs[index_for_plotting] * 0.1), ys[index_for_plotting] + (ys[index_for_plotting] * 0.01)), arrowprops=dict(facecolor='black', shrink=0.05))
+                    _ = ax.plot(xs[index_for_plotting], ys[index_for_plotting], 'bo', ms=10)
+                    _ = ax.annotate(bpm_label, 
+                                    xy=(xs[index_for_plotting], ys[index_for_plotting]), 
+                                    xytext=(xs[index_for_plotting] + (xs[index_for_plotting] * 0.1), ys[index_for_plotting] + (ys[index_for_plotting] * 0.01)),
+                                    arrowprops=dict(facecolor='black', shrink=0.05))
                 else:
                     LOGGER.info(
                         "No peaks detected anyway")
@@ -1576,7 +1573,7 @@ def final_dist_graph(bpm_fourier,  out_dir):
         fig.savefig(output_dir)
         plt.close(fig)
 
-    except:
+    except Exception as e:
         pass
 
 # final_dist_graph(bpm_fourier)    ## debug
@@ -1654,7 +1651,7 @@ def crop_2(video, args, embryo_coordinates, resulting_dict_from_crop, video_meta
         try:
             cut_image = img[int(embryo_coordinates[0])-embryo_size: int(embryo_coordinates[0]) +
                             embryo_size, int(embryo_coordinates[1])-embryo_size: int(embryo_coordinates[1])+embryo_size]
-        except:
+        except Exception as e:
             cut_image = img
             LOGGER.info(
                 "Problems cropping image (image dimensions in -s paramter)")
@@ -1679,72 +1676,69 @@ def crop_2(video, args, embryo_coordinates, resulting_dict_from_crop, video_meta
 ############################################################################################################
 
 # DEPRECATED: substituted by crop_2 (above)
+# def crop(video):
+#     LOGGER.info("Cropping video")
+#     circle_x = []
+#     circle_y = []
+#     circle_radii = []
 
+#     video_cropped = []
 
-def crop(video):
-    LOGGER.info("Cropping video")
-    circle_x = []
-    circle_y = []
-    circle_radii = []
+#     success_count = 0
+#     for frame, i in zip(video, range(5)):
+#         # Detect embryo with Hough Circle Detection
+#         # Circle coords, can be used as cropping parameters
+#         circle, x1, y1, x2, y2 = detectEmbryo(frame)
 
-    video_cropped = []
+#         if circle is not None:
+#             circle_x.append(circle[0])
+#             circle_y.append(circle[1])
+#             circle_radii.append(circle[2])
 
-    success_count = 0
-    for frame, i in zip(video, range(5)):
-        # Detect embryo with Hough Circle Detection
-        # Circle coords, can be used as cropping parameters
-        circle, x1, y1, x2, y2 = detectEmbryo(frame)
+#     # Embryo Circle
+#     if len(circle_x) > 0:
+#         for x, y, r in zip(circle_x, circle_y, circle_radii):
 
-        if circle is not None:
-            circle_x.append(circle[0])
-            circle_y.append(circle[1])
-            circle_radii.append(circle[2])
+#             x_coord = x
+#             y_coord = y
+#             radius = r
 
-    # Embryo Circle
-    if len(circle_x) > 0:
-        for x, y, r in zip(circle_x, circle_y, circle_radii):
+#             if x_coord is not None:
 
-            x_coord = x
-            y_coord = y
-            radius = r
+#                 x_counts = Counter(x_coord)
+#                 y_counts = Counter(y_coord)
+#                 rad_counts = Counter(radius)
 
-            if x_coord is not None:
+#         # Use most common circle coords for the embryo
+#         embryo_x, _ = x_counts.most_common(1)[0]
+#         embryo_y, _ = y_counts.most_common(1)[0]
+#         embryo_rad, _ = rad_counts.most_common(1)[0]
 
-                x_counts = Counter(x_coord)
-                y_counts = Counter(y_coord)
-                rad_counts = Counter(radius)
+#     else:
+#         embryo_x = None
+#         embryo_y = None
+#         embryo_rad = None
 
-        # Use most common circle coords for the embryo
-        embryo_x, _ = x_counts.most_common(1)[0]
-        embryo_y, _ = y_counts.most_common(1)[0]
-        embryo_rad, _ = rad_counts.most_common(1)[0]
+#     if embryo_x and embryo_y and embryo_rad:
+#         y1 = embryo_y - embryo_rad - 50
+#         y2 = embryo_y + embryo_rad + 50
+#         x1 = embryo_x - embryo_rad - 50
+#         x2 = embryo_x + embryo_rad + 50
 
-    else:
-        embryo_x = None
-        embryo_y = None
-        embryo_rad = None
+#     else:
+#         LOGGER.warning(
+#             "Couldn't detect circles in video. Cutting approximately around edges.")
+#         shape = video[0].shape
 
-    if embryo_x and embryo_y and embryo_rad:
-        y1 = embryo_y - embryo_rad - 50
-        y2 = embryo_y + embryo_rad + 50
-        x1 = embryo_x - embryo_rad - 50
-        x2 = embryo_x + embryo_rad + 50
+#         y1 = int(shape[0] * 0.3)
+#         y2 = int(shape[0] * 0.7)
+#         x1 = int(shape[1] * 0.3)
+#         x2 = int(shape[1] * 0.7)
+#     for frame in video:
+#         # crop_img = img[y1 : y2, x1: x2]
+#         video_cropped.append(frame[y1: y2, x1: x2])
 
-    else:
-        LOGGER.warning(
-            "Couldn't detect circles in video. Cutting approximately around edges.")
-        shape = video[0].shape
-
-        y1 = int(shape[0] * 0.3)
-        y2 = int(shape[0] * 0.7)
-        x1 = int(shape[1] * 0.3)
-        x2 = int(shape[1] * 0.7)
-    for frame in video:
-        # crop_img = img[y1 : y2, x1: x2]
-        video_cropped.append(frame[y1: y2, x1: x2])
-
-    return video_cropped
-
+#     return video_cropped
 
 def save_video(video, fps, outdir, filename):
     vid_frames = [frame for frame in video if frame is not None]
@@ -1763,8 +1757,6 @@ def save_video(video, fps, outdir, filename):
     out.release()
 
 # Detect heart region of interest (HROI)
-
-
 def HROI(sorted_frames, norm_frames, hroi_ax):
     # Only process if less than 5% frames are empty
     if sum(frame is None for frame in sorted_frames) > len(sorted_frames) * 0.05:
@@ -1870,8 +1862,7 @@ def HROI(sorted_frames, norm_frames, hroi_ax):
                               alpha=0.7, bg_label=0, bg_color=None, colors=[(1, 0, 0)])
 
     # Generate figure showing with potential heart region highlighted
-    hroi_ax = heartQC_plot(hroi_ax, f0_grey, heart_roi,
-                           heart_roi_clean, overlay)
+    hroi_ax = heartQC_plot(hroi_ax, f0_grey, heart_roi, heart_roi_clean, overlay)
 
     # Check if heart region was detected, i.e. if sum(masked) > 0
     # and limit number of possible heart regions to 3 or fewer
@@ -1882,7 +1873,6 @@ def HROI(sorted_frames, norm_frames, hroi_ax):
     # stop_frame is not used anymore
     return embryo, final_mask, hroi_ax
 
-
 # Run normally, Fourier in segemented area
 def fourier_bpm(masked_greys, times, empty_frames, frame2frame_sec, args, out_dir):
     # Signal per pixel
@@ -1891,8 +1881,7 @@ def fourier_bpm(masked_greys, times, empty_frames, frame2frame_sec, args, out_di
     # Perform Fourier Transform on each pixel in segmented area
     out_fourier = os.path.join(out_dir, "pixel_fourier.png")
     fig, ax = plt.subplots(figsize=(10, 7))
-    ax, highest_freqs = PixelFourier(
-        pixel_signals, times, empty_frames, frame2frame_sec, args['threads'], pixel_num=1000, plot=True)
+    ax, highest_freqs = PixelFourier(pixel_signals, times, empty_frames, frame2frame_sec, args['threads'], pixel_num=1000, plot=True)
     plt.savefig(out_fourier)
 
     # plt.imshow(ax)
@@ -1903,16 +1892,13 @@ def fourier_bpm(masked_greys, times, empty_frames, frame2frame_sec, args, out_di
     # Plot the density of fourier transform global maxima across pixels
     out_kde = os.path.join(out_dir, "pixel_rate.png")
     fig, ax = plt.subplots(1, 1, figsize=(10, 7))
-    ax, bpm_fourier = PixelFreqs(
-        highest_freqs, args['average'], peak_filter=True, slow_mode=False)
+    ax, bpm_fourier = PixelFreqs(highest_freqs, args['average'], peak_filter=True, slow_mode=False)
     plt.savefig(out_kde)
     plt.close()
 
     return bpm_fourier
 
 # Run in slow mode, Fourier on every pixel
-
-
 def fourier_bpm_slowmode(norm_frames, times, empty_frames, frame2frame_sec, args, out_dir):
     # Resize frames to make faster
     # TODO: That just results in wrong measurements, as the heart may be cut.
@@ -1923,18 +1909,18 @@ def fourier_bpm_slowmode(norm_frames, times, empty_frames, frame2frame_sec, args
 
     # Perform Fourier Transform on every pixel
     # NOTE: plot=True too expensive and won't finish at the moment
-    highest_freqs2 = PixelFourier(
-        all_pixel_sigs, times, empty_frames, frame2frame_sec, args['threads'], plot=False)
+    highest_freqs2 = PixelFourier(all_pixel_sigs, times, empty_frames, frame2frame_sec, args['threads'], plot=False)
+    
     # Plot the density of fourier transform global maxima across pixels
     out_kde2 = os.path.join(out_dir, "pixel_rate_all(slowmode).png")
     fig2, ax2 = plt.subplots(1, 1, figsize=(10, 7))
-    ax2, bpm_fourier = PixelFreqs(
-        highest_freqs2, args['average'], peak_filter=False, slow_mode=True)
+    
+    ax2, bpm_fourier = PixelFreqs(highest_freqs2, args['average'], peak_filter=False, slow_mode=True)
+    
     plt.savefig(out_kde2)
     plt.close()
 
     return bpm_fourier
-
 
 def bpm_trace(masked_greys, frame2frame_sec, times, empty_frames, out_dir):
     LOGGER.info("Statistical analysis")
@@ -1999,12 +1985,11 @@ def bpm_trace(masked_greys, frame2frame_sec, times, empty_frames, out_dir):
 
 # run the algorithm on a well video
 # TODO: Move data consistency check like duplicate frames, empty frames somewhere else before maybe.
-
-
 def run(video, args, video_metadata):
     LOGGER.info("Starting algorithmic analysis")
     bpm = None
-    # Create Outdir for pictures
+
+    ################################ Pre-Processing
     # Add well position to output directory path
     out_dir = os.path.join(args['outdir'], video_metadata['channel'],
                            video_metadata['loop'] + '-' + video_metadata['well_id'])
@@ -2043,7 +2028,7 @@ def run(video, args, video_metadata):
         LOGGER.info("Defined fps: " + str(round(fps, 2)))
 
 
-    # Normalize Frames
+    ################################# Normalize Frames
     LOGGER.info("Normalizing frames")
     # Normalize frames
     norm_frames = normVideo(sorted_frames)
@@ -2051,37 +2036,33 @@ def run(video, args, video_metadata):
     LOGGER.info("Writing video")
     save_video(norm_frames, fps, out_dir, "embryo.mp4")
 
-    # Detect HROI
-    # needs: sorted_frames
-    LOGGER.info("Detecting HROI")
-
-    # Prepare outfigure
-    out_fig = os.path.join(out_dir, "embryo_heart_roi.png")
-    fig, hroi_ax = plt.subplots(2, 2, figsize=(15, 15))
-
-    # Get frame timestamps, from 0, in seconds for fourier transform
+    ################################ Get frame timestamps, from 0, in seconds for fourier transform
     frame2frame = 0
     nr_of_frames = len(video)
     if not args['fps']:
-        timespan = (int(sorted_times[nr_of_frames-1]
-                        ) - int(sorted_times[0])) / 1000
+        timespan = (int(sorted_times[nr_of_frames-1]) - int(sorted_times[0])) / 1000
         frame2frame = timespan / nr_of_frames  # 1 / fps
     else:
         frame2frame = 1/args['fps']
     final_time = frame2frame * nr_of_frames
     times = np.arange(start=0, stop=final_time, step=frame2frame)
 
-    # Detect HROI and write into figure. stop_frame = 0, if not movement detected, otherwise set to frame index
+    ################################ Detect HROI and write into figure. 
+    # Prepare outfigure
+    out_fig = os.path.join(out_dir, "embryo_heart_roi.png")
+    fig, hroi_ax = plt.subplots(2, 2, figsize=(15, 15))
+
+    # stop_frame = 0, if not movement detected, otherwise set to frame index
+    # Detect HROI
+    LOGGER.info("Detecting HROI")
     try:
-        embryo, mask, hroi_ax = HROI(
-            sorted_frames, norm_frames, hroi_ax)
-    except:
-        if args['slowmode'] and not bpm:  # or not bpm:
+        embryo, mask, hroi_ax = HROI(sorted_frames, norm_frames, hroi_ax)
+    except Exception as e:
+        if args['slowmode']:
             LOGGER.info("Trying in slow mode2")
             norm_frames_grey = greyFrames(norm_frames, 0)
 
-            bpm = fourier_bpm_slowmode(
-                norm_frames_grey, times, [], frame2frame, args, out_dir)
+            bpm = fourier_bpm_slowmode(norm_frames_grey, times, [], frame2frame, args, out_dir)
             return bpm
 
     # Save Figure
@@ -2089,7 +2070,7 @@ def run(video, args, video_metadata):
     plt.show()
     plt.close()
 
-    # Mask frames
+    ################################ Mask frames
     masked_greys = []
     masked_frames = []
     empty_frames = []
@@ -2150,30 +2131,27 @@ def run(video, args, video_metadata):
     # Draw bpm-trace
     try:
         bpm_trace(masked_greys, frame2frame, times, empty_frames, out_dir)
-    except:
-        LOGGER.info("A error occurred trying Fourier in bpm_trace function")
+    except Exception as e:
+        LOGGER.exception("Whislst drawing the bpm trace")
 
-    # Fourier Frequency estimation
+    ################################ Fourier Frequency estimation
     LOGGER.info("Fourier frequency evaluation")
 
     # Run normally, Fourier in segemented area
-
     try:
-        bpm = fourier_bpm(masked_greys, times, empty_frames,
-                          frame2frame, args, out_dir)
-    except:
-        LOGGER.info("A error occurred trying Fourier in segemented area")
+        bpm = fourier_bpm(masked_greys, times, empty_frames, frame2frame, args, out_dir)
+    except Exception as e:
+        LOGGER.exception("Whilst trying Fourier analysis of segemented area")
 
     if not bpm:
         LOGGER.info("No bpm detected")
 
     # Run in slow mode, Fourier on every pixel
-    if args['slowmode'] and not bpm:  # or not bpm:
+    if args['slowmode'] and not bpm:
         LOGGER.info("Trying in slow mode1")
         # stop_frame is not used anymore
         norm_frames_grey = greyFrames(norm_frames)
-        bpm = fourier_bpm_slowmode(
-            norm_frames_grey, times, empty_frames, frame2frame, args, out_dir)
+        bpm = fourier_bpm_slowmode(norm_frames_grey, times, empty_frames, frame2frame, args, out_dir)
 
     plt.close('all')  # fixed memory leak
     return bpm

--- a/src/segment_heart.py
+++ b/src/segment_heart.py
@@ -2037,8 +2037,11 @@ def run(video, args, video_metadata):
         total_time = (timestamp_final - timestamp0) / 1000
         # fps = int(len(sorted_times) / round(total_time))
         fps = len(sorted_times) / total_time
+        LOGGER.info("Calculated fps: " + str(round(fps, 2)))
     else:
         fps = args['fps']
+        LOGGER.info("Defined fps: " + str(round(fps, 2)))
+
 
     # Normalize Frames
     LOGGER.info("Normalizing frames")

--- a/src/segment_heart.py
+++ b/src/segment_heart.py
@@ -285,7 +285,7 @@ def detectEmbryo(frame):
 # Convert all frames in a list into greyscale
 
 
-def greyFrames(frames, stop_frame=0):  # stop_frame is not used anymore
+def greyFrames(frames):  # stop_frame is not used anymore
 
     for frame in frames:
         if frame is not None:
@@ -310,9 +310,7 @@ def greyFrames(frames, stop_frame=0):  # stop_frame is not used anymore
         grey_frames.append(grey_frame)
         frame_number += 1
 
-        # if stop_frame in greater than 0, it means that the embryo flipped around, then we need to skip frames beyond the frame which the embryo moves
-        if (stop_frame > 0) and (frame_number >= stop_frame):   # stop_frame is not used anymore
-            break
+       
     #grey_frames = grey_frames[100:]
     return(grey_frames)
 
@@ -1799,7 +1797,7 @@ def HROI(sorted_frames, norm_frames, hroi_ax):
     # Detect heart region (and possibly blood vessels)
     # by determining the differences across windows of frames
     j = start_frame + 1
-    stop_frame = 0    # stop_frame is not used anymore
+    
     while j < len(norm_frames):
 
         frame = norm_frames[j]
@@ -1807,14 +1805,11 @@ def HROI(sorted_frames, norm_frames, hroi_ax):
         if frame is not None:
 
             masked_frame, triangle_thresh, thresh, movement = rolling_diff(
-                j, norm_frames, win_size=2, direction="reverse", min_area=150)  # I´ve added thresh just to test
+                j, norm_frames, win_size=2, direction="reverse", min_area=150)  # I´ve added thresh just to test; "movement" is not used anymore
 
             # TODO: If the movement happens early, all data is thrown away and the algorithm fails.
             # if movement is true, it means that the embyio flip around. Then, save the frame number and and skip all following frames. The frame number will be used to try run the fast method if is the case
-            if movement == True:
-                stop_frame = j
-                break
-
+            
             heart_roi = cv2.add(heart_roi, triangle_thresh)
             embryo.append(masked_frame)
             cv2.add(thresh, blue_print)
@@ -1882,7 +1877,7 @@ def HROI(sorted_frames, norm_frames, hroi_ax):
         raise RuntimeError("Couldn't detect a HROI")
 
     # stop_frame is not used anymore
-    return embryo, final_mask, hroi_ax, stop_frame
+    return embryo, final_mask, hroi_ax
 
 
 # Run normally, Fourier in segemented area
@@ -2072,7 +2067,7 @@ def run(video, args, video_metadata):
 
     # Detect HROI and write into figure. stop_frame = 0, if not movement detected, otherwise set to frame index
     try:
-        embryo, mask, hroi_ax, stop_frame = HROI(
+        embryo, mask, hroi_ax = HROI(
             sorted_frames, norm_frames, hroi_ax)
     except:
         if args['slowmode'] and not bpm:  # or not bpm:
@@ -2170,7 +2165,7 @@ def run(video, args, video_metadata):
     if args['slowmode'] and not bpm:  # or not bpm:
         LOGGER.info("Trying in slow mode1")
         # stop_frame is not used anymore
-        norm_frames_grey = greyFrames(norm_frames, stop_frame=0)
+        norm_frames_grey = greyFrames(norm_frames)
         bpm = fourier_bpm_slowmode(
             norm_frames_grey, times, empty_frames, frame2frame, args, out_dir)
 

--- a/src/segment_heart.py
+++ b/src/segment_heart.py
@@ -1361,9 +1361,6 @@ def PixelFreqs(frequencies, average_values, figsize=(10, 7), heart_range=(0.5, 5
                     peaks, _ = find_peaks(squared_list, prominence=(0.05))
 
                 x_values = [xs[i] for i in peaks]
-                print(x_values)
-                for z in x_values:
-                    print(z * 60)
                 highest_value = max(x_values)
                 x_list = xs.tolist()
                 index_for_plotting = x_list.index(highest_value)
@@ -1540,7 +1537,7 @@ def embryo_detection(video):
         # clear 10% of the image' borders as some dark areas may exists
         thresh_img_final[0:int(thresh_img_final.shape[1]*0.1),
                          0:thresh_img_final.shape[0]] = 255
-        thresh_img_final[int(thresh_img_final.shape[1]*0.9)                         :thresh_img_final.shape[1], 0:thresh_img_final.shape[0]] = 255
+        thresh_img_final[int(thresh_img_final.shape[1]*0.9):thresh_img_final.shape[1], 0:thresh_img_final.shape[0]] = 255
 
         thresh_img_final[0:thresh_img_final.shape[1],
                          0:int(thresh_img_final.shape[0]*0.1)] = 255
@@ -1823,7 +1820,6 @@ def fourier_bpm(masked_greys, times, empty_frames, frame2frame_sec, args, out_di
     # Signal per pixel
     pixel_signals = PixelSignal(masked_greys)
 
-    # print('not slow')
     # Perform Fourier Transform on each pixel in segmented area
     out_fourier = os.path.join(out_dir, "pixel_fourier.png")
     fig, ax = plt.subplots(figsize=(10, 7))
@@ -1840,7 +1836,7 @@ def fourier_bpm(masked_greys, times, empty_frames, frame2frame_sec, args, out_di
     out_kde = os.path.join(out_dir, "pixel_rate.png")
     fig, ax = plt.subplots(1, 1, figsize=(10, 7))
     ax, bpm_fourier = PixelFreqs(
-        highest_freqs, args['average'], peak_filter=True)
+        highest_freqs, args['average'], peak_filter=True, slow_mode=False)
     plt.savefig(out_kde)
     plt.close()
 
@@ -1867,7 +1863,7 @@ def fourier_bpm_slowmode(norm_frames, times, empty_frames, frame2frame_sec, args
     out_kde2 = os.path.join(out_dir, "pixel_rate_all(slowmode).png")
     fig2, ax2 = plt.subplots(1, 1, figsize=(10, 7))
     ax2, bpm_fourier = PixelFreqs(
-        highest_freqs2, args['average'], peak_filter=False)
+        highest_freqs2, args['average'], peak_filter=False, slow_mode=True)
     plt.savefig(out_kde2)
     plt.close()
 

--- a/src/segment_heart.py
+++ b/src/segment_heart.py
@@ -1435,24 +1435,26 @@ def PixelFreqs(frequencies, average_values, figsize=(10, 7), heart_range=(0.5, 5
                 _ = ax.annotate(bpm_label, xy=(xs[index_for_plotting], ys[index_for_plotting]), xytext=(xs[index_for_plotting] + (
                     xs[index_for_plotting] * 0.1), ys[index_for_plotting] + (ys[index_for_plotting] * 0.01)), arrowprops=dict(facecolor='black', shrink=0.05))
 
-            else:  # more than 2 peaks, first delete the farthest peak from the peaks average,as is is suposed to be a error.
+            # more than 2 peaks, first delete the farthest peak from the peaks average,as is is suposed to be a error.
+            elif len(peaks) > 2:
                 LOGGER.info("Found more than 2 peaks in slow mode")
-                averaged_peak = statistics.mean(peaks)
                 x_values = [xs[i] for i in peaks]
+                averaged_peak_values = statistics.mean(x_values)
                 def absolute_difference_function(list_value): return abs(
-                    list_value - averaged_peak)
+                    list_value - averaged_peak_values)
                 farthest_value = max(
                     x_values, key=absolute_difference_function)
-                x_list = xs.tolist()
-                index_for_deletion = x_list.index(farthest_value)
-                del peaks[index_for_deletion]
+                #x_list = xs.tolist()
+                index_for_deletion = x_values.index(farthest_value)
+                peaks = np.delete(peaks, index_for_deletion)
 
-                # now, with a correct peak list, calculate again using the peak that represents the lower bpm
-                x_values = [xs[i] for i in peaks]
-                lowest_value = min(x_values)
+                # now, with a correct peak list, calculate again using the higher peak
+                y_values = [ys[i] for i in peaks]
+                highest_value = max(y_values)
+                y_list = ys.tolist()
                 x_list = xs.tolist()
-                index_for_plotting = x_list.index(lowest_value)
-                bpm = lowest_value * 60
+                index_for_plotting = y_list.index(highest_value)
+                bpm = x_list[index_for_plotting] * 60
                 bpm = np.around(bpm, decimals=2)
 
                 # Label plot with peak representing the lowest bpm
@@ -1461,6 +1463,10 @@ def PixelFreqs(frequencies, average_values, figsize=(10, 7), heart_range=(0.5, 5
                             ys[index_for_plotting], 'bo', ms=10)
                 _ = ax.annotate(bpm_label, xy=(xs[index_for_plotting], ys[index_for_plotting]), xytext=(xs[index_for_plotting] + (
                     xs[index_for_plotting] * 0.1), ys[index_for_plotting] + (ys[index_for_plotting] * 0.01)), arrowprops=dict(facecolor='black', shrink=0.05))
+
+            else:
+                LOGGER.info("no peaks detected")
+                bpm = None
 
     return(ax, bpm)
 
@@ -1577,8 +1583,7 @@ def embryo_detection(video):
         # clear 10% of the image' borders as some dark areas may exists
         thresh_img_final[0:int(thresh_img_final.shape[1]*0.1),
                          0:thresh_img_final.shape[0]] = 255
-        thresh_img_final[int(thresh_img_final.shape[1]*0.9)
-                             :thresh_img_final.shape[1], 0:thresh_img_final.shape[0]] = 255
+        thresh_img_final[int(thresh_img_final.shape[1]*0.9)                         :thresh_img_final.shape[1], 0:thresh_img_final.shape[0]] = 255
 
         thresh_img_final[0:thresh_img_final.shape[1],
                          0:int(thresh_img_final.shape[0]*0.1)] = 255

--- a/src/segment_heart.py
+++ b/src/segment_heart.py
@@ -1389,9 +1389,16 @@ def PixelFreqs(frequencies, average_values, figsize=(10, 7), heart_range=(0.5, 5
 
                 if max_peak > (average_peaks*2):
                     LOGGER.info(
-                        "The peak is very higher than the average values, trying to detected hidden peaks by square rooting the values")
+                        "The peak is very higher than the average values and can be abnormal. We will try to detected hidden peaks by square rooting the values")
                     squared_list = np.sqrt(ys)
                     peaks, _ = find_peaks(squared_list, prominence=(0.05))
+
+                    if len(peaks) > 1:
+                        LOGGER.info(
+                            "Found " + str(len(peaks)) + " peaks. We will select the one that represents the highest bpm")
+                    else:
+                        LOGGER.info(
+                            "No aditional peak detected, using the unique peak to detect bpm")
 
                 x_values = [xs[i] for i in peaks]
                 highest_value = max(x_values)
@@ -1570,7 +1577,8 @@ def embryo_detection(video):
         # clear 10% of the image' borders as some dark areas may exists
         thresh_img_final[0:int(thresh_img_final.shape[1]*0.1),
                          0:thresh_img_final.shape[0]] = 255
-        thresh_img_final[int(thresh_img_final.shape[1]*0.9)                         :thresh_img_final.shape[1], 0:thresh_img_final.shape[0]] = 255
+        thresh_img_final[int(thresh_img_final.shape[1]*0.9)
+                             :thresh_img_final.shape[1], 0:thresh_img_final.shape[0]] = 255
 
         thresh_img_final[0:thresh_img_final.shape[1],
                          0:int(thresh_img_final.shape[0]*0.1)] = 255

--- a/src/segment_heart.py
+++ b/src/segment_heart.py
@@ -310,7 +310,6 @@ def greyFrames(frames):  # stop_frame is not used anymore
         grey_frames.append(grey_frame)
         frame_number += 1
 
-       
     #grey_frames = grey_frames[100:]
     return(grey_frames)
 
@@ -1327,15 +1326,20 @@ def PixelFreqs(frequencies, average_values, figsize=(10, 7), heart_range=(0.5, 5
                 # verify if user has inserted a average argument -a. 0 means No parameters inserted
                 if not average_values:
                     LOGGER.info("found " + str(len(peaks)) +
-                                " peak(s), selected the one which represents the lower BPM")
+                                " peak(s), selected the one which represents the lower BPM, but above 50")
                     LOGGER.info(
                         "in these cases, inserting an expected average as agument -a in bash command line can help to choose the right peak. E.g.: -a 98")
 
                     x_values = [xs[i] for i in peaks]
                     lowest_value = min(x_values)
+                    highest_value = max(x_values)
                     x_list = xs.tolist()
                     index_for_plotting = x_list.index(lowest_value)
                     bpm = lowest_value * 60
+                    # invert peaks if final bpm is lower than 50 (unreal)
+                    if bpm < 50:
+                        bpm = highest_value * 60
+                        index_for_plotting = x_list.index(highest_value)
                     bpm = np.around(bpm, decimals=2)
                     bpm_label = str(int(bpm)) + " bpm"
 
@@ -1603,8 +1607,7 @@ def embryo_detection(video):
         # clear 10% of the image' borders as some dark areas may exists
         thresh_img_final[0:int(thresh_img_final.shape[1]*0.1),
                          0:thresh_img_final.shape[0]] = 255
-        thresh_img_final[int(thresh_img_final.shape[1]*0.9)
-                             :thresh_img_final.shape[1], 0:thresh_img_final.shape[0]] = 255
+        thresh_img_final[int(thresh_img_final.shape[1]*0.9):thresh_img_final.shape[1], 0:thresh_img_final.shape[0]] = 255
 
         thresh_img_final[0:thresh_img_final.shape[1],
                          0:int(thresh_img_final.shape[0]*0.1)] = 255
@@ -1797,7 +1800,7 @@ def HROI(sorted_frames, norm_frames, hroi_ax):
     # Detect heart region (and possibly blood vessels)
     # by determining the differences across windows of frames
     j = start_frame + 1
-    
+
     while j < len(norm_frames):
 
         frame = norm_frames[j]
@@ -1809,7 +1812,7 @@ def HROI(sorted_frames, norm_frames, hroi_ax):
 
             # TODO: If the movement happens early, all data is thrown away and the algorithm fails.
             # if movement is true, it means that the embyio flip around. Then, save the frame number and and skip all following frames. The frame number will be used to try run the fast method if is the case
-            
+
             heart_roi = cv2.add(heart_roi, triangle_thresh)
             embryo.append(masked_frame)
             cv2.add(thresh, blue_print)


### PR DESCRIPTION
 - I have modified the behaviour of the --slow-mode option. Now, if set, the script will try slow-mode every time the main script fails.
 
 - I have modified the way the script detect the peaks, that is, for each different situation, the script can detect the lowest peak, the highest peak, and soo on. These are defined by logic, for example, if one of the two peaks is extremely high than the signal average, then it is probably an error and will not be selected. 
Another example: if we have two similar peaks in high and longitude, then the second peak is probably the two-chamber ROI error, then, is logic that only the first peak be selected.  

I have done some statistics to prove that this script increases accuracy, and will show you guys soon. I am just inserting a pull request to make this version in the queue and avoid conflicts.